### PR TITLE
Fix #86861: Respect top_level property of children when drawing selection box

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4100,6 +4100,9 @@ AABB Node3DEditorViewport::_calculate_spatial_bounds(const Node3D *p_parent, boo
 		Node3D *child = Object::cast_to<Node3D>(p_parent->get_child(i));
 		if (child) {
 			AABB child_bounds = _calculate_spatial_bounds(child, false);
+			if (child->is_set_as_top_level()) {
+				child_bounds = p_parent->get_global_transform().xform_inv(child_bounds);
+			}
 
 			if (bounds.size == Vector3() && p_parent) {
 				bounds = child_bounds;


### PR DESCRIPTION
Previously, children with `top_level=true` were bounded as if they were `top_level=false`. This led to situations where selection boxes were drawn incorrectly. The box would appear offset from the object it was meant to render onto.

`Node3DEditorViewport::_calculate_spatial_bounds` traverses the scene tree to calculate bounds in a bottom-up fashion. Children boxes are transformed relative to their parents until we reach the top-level parent (the one the function was initially called on). The final return value is a bounding box in the top-level parent's local space.

On [line 2812][] in the caller, the top-level node's transform is applied to get the final selection box in global space.

This fix applies the inverse of the parent's global transform to children with `top_level=true`. This counteracts the transforms we apply while traversing the scene tree. It also counteracts the caller's final transform on [line 2812][].

[line 2812]: https://github.com/godotengine/godot/blob/9b522ac1a85cab1a7a867b7a9f3bb102d9376ac2/editor/plugins/node_3d_editor_plugin.cpp#L2812