### PR TITLE
Drag-and-drop instantiation improvements

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4126,7 +4126,7 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos) const 
 	return world_pos + world_ray * FALLBACK_DISTANCE;
 }
 
-AABB Node3DEditorViewport::_calculate_spatial_bounds(const Node3D *p_parent, const Transform3D *p_bounds_orientation) {
+AABB Node3DEditorViewport::_calculate_spatial_bounds(const Node3D *p_parent, const bool p_omit_top_level, const Transform3D *p_bounds_orientation) {
 	AABB bounds;
 
 	Transform3D bounds_orientation;
@@ -4152,8 +4152,8 @@ AABB Node3DEditorViewport::_calculate_spatial_bounds(const Node3D *p_parent, con
 
 	for (int i = 0; i < p_parent->get_child_count(); i++) {
 		const Node3D *child = Object::cast_to<Node3D>(p_parent->get_child(i));
-		if (child) {
-			const AABB child_bounds = _calculate_spatial_bounds(child, &bounds_orientation);
+		if (child && !(p_omit_top_level && child->is_set_as_top_level())) {
+			const AABB child_bounds = _calculate_spatial_bounds(child, p_omit_top_level, &bounds_orientation);
 			bounds.merge_with(child_bounds);
 		}
 	}

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4210,6 +4210,10 @@ void Node3DEditorViewport::_create_preview_node(const Vector<String> &files) con
 					if (instance) {
 						instance = _sanitize_preview_node(instance);
 						preview_node->add_child(instance);
+						Node3D *node_3d = Object::cast_to<Node3D>(instance);
+						if (node_3d) {
+							node_3d->set_as_top_level(false);
+						}
 					}
 				}
 			}
@@ -4412,8 +4416,12 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 		}
 
 		Transform3D new_tf = node3d->get_transform();
-		new_tf.origin = parent_tf.affine_inverse().xform(preview_node_pos + node3d->get_position());
-		new_tf.basis = parent_tf.affine_inverse().basis * new_tf.basis;
+		if (node3d->is_set_as_top_level()) {
+			new_tf.origin += preview_node_pos;
+		} else {
+			new_tf.origin = parent_tf.affine_inverse().xform(preview_node_pos + node3d->get_position());
+			new_tf.basis = parent_tf.affine_inverse().basis * new_tf.basis;
+		}
 
 		undo_redo->add_do_method(instantiated_scene, "set_transform", new_tf);
 	}

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4115,12 +4115,8 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos) const 
 		// This normal-aligned Basis allows us to create an AABB that can fit on the surface plane as snugly as possible.
 		const Transform3D bb_transform = Transform3D(bb_basis, preview_node->get_transform().origin);
 		const AABB preview_node_bb = _calculate_spatial_bounds(preview_node, true, &bb_transform);
-		// Use the local space of the `preview_node_bb` for our distance calculation.
-		const Vector3 surface_normal = Vector3(1, 0, 0);
-		const Vector3 preview_node_origin = Vector3(0, 0, 0);
-		const Vector3 support = preview_node_bb.get_support(-surface_normal);
-		const Plane support_plane = Plane(surface_normal, support);
-		const float offset_distance = support_plane.distance_to(preview_node_origin);
+		// The x-axis's alignment with the surface normal also makes it trivial to get the distance from `preview_node`'s origin at (0, 0, 0) to the correct AABB face.
+		const float offset_distance = -preview_node_bb.position.x;
 
 		// `result_offset` is in global space.
 		const Vector3 result_offset = result.position + result.normal * offset_distance;

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -435,7 +435,7 @@ private:
 	Point2i _get_warped_mouse_motion(const Ref<InputEventMouseMotion> &p_ev_mouse_motion) const;
 
 	Vector3 _get_instance_position(const Point2 &p_pos) const;
-	static AABB _calculate_spatial_bounds(const Node3D *p_parent, const Transform3D *p_bounds_orientation = nullptr);
+	static AABB _calculate_spatial_bounds(const Node3D *p_parent, const bool p_omit_top_level = false, const Transform3D *p_bounds_orientation = nullptr);
 
 	Node *_sanitize_preview_node(Node *p_node) const;
 

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -435,7 +435,7 @@ private:
 	Point2i _get_warped_mouse_motion(const Ref<InputEventMouseMotion> &p_ev_mouse_motion) const;
 
 	Vector3 _get_instance_position(const Point2 &p_pos) const;
-	static AABB _calculate_spatial_bounds(const Node3D *p_parent, const Node3D *p_top_level_parent = nullptr);
+	static AABB _calculate_spatial_bounds(const Node3D *p_parent, const Transform3D *p_bounds_orientation = nullptr);
 
 	Node *_sanitize_preview_node(Node *p_node) const;
 


### PR DESCRIPTION
There are two main changes:
- Offset drag-instantiated scenes to place them on top of the targeted surface, raised along the surface's normal.
- Fix dragging behavior and appearance of scenes that have top-level set to true. Now, they can be positioned like non-top-level nodes while being dragged. Once they're dropped, they will remain at the same global position with their top-level flag set to true.

I left-in an intermediate commit with the full distance logic before I simplified it. That will be useful if we ever implement a better way to calculate bounds than merging all the children bounding boxes.